### PR TITLE
fix: runtime cdn url

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -53,7 +53,7 @@
     <script src="https://cdn.jsdelivr.net/npm/js-beautify@1.10.3/js/lib/beautifier.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.16.2/build/highlight.min.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/gh/wenyan-lang/wenyan@cdn/core.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@wenyanlang/core@0.3.2/index.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/wenyan-lang/wenyan@cdn/examples.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/wenyan-lang/wenyan@cdn/render.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jszip@3.6.0/dist/jszip.min.js" defer></script>


### PR DESCRIPTION
之前CDN版本的webpack编译有问题，加载依赖模块的时候会报错。